### PR TITLE
카테고리 변경에 따른 ui 수정 및 뉴스 api 연동

### DIFF
--- a/src/common/apis/trip/types.ts
+++ b/src/common/apis/trip/types.ts
@@ -6,7 +6,7 @@ export interface NewsSummary {
   title: string;
   content: string;
   url: string;
-  category: string;
+  img: string;
 }
 
 export interface WeatherResponse {

--- a/src/pages/trip/index/components/NewsSection.tsx
+++ b/src/pages/trip/index/components/NewsSection.tsx
@@ -6,6 +6,8 @@ interface NewsSectionProps {
   calendarId: string;
 }
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 const NewsSection = ({ calendarId }: NewsSectionProps) => {
   const { data: newsData, isLoading, isError, error } = useNews(calendarId);
 
@@ -32,13 +34,13 @@ const NewsSection = ({ calendarId }: NewsSectionProps) => {
       </MenuBar>
       <NewsCardList>
         {newsData?.itemList.map((news, index) => (
-          <NewsCard key={index} onClick={() => window.open(news?.url, '_blank')}>
+          <NewsCard key={index} onClick={() => window.open(news.url, '_blank')}>
             <ImageWrapper>
-              <Image src={news.img} alt="news" />
+              <Image src={`${BASE_URL}${news.img}`} alt="news" />
             </ImageWrapper>
             <TextWrapper>
-              <Title>{news?.title}</Title>
-              <Description>{news?.content}</Description>
+              <Title>{news.title}</Title>
+              <Description>{news.content}</Description>
             </TextWrapper>
           </NewsCard>
         ))}
@@ -47,33 +49,8 @@ const NewsSection = ({ calendarId }: NewsSectionProps) => {
   );
 };
 
-const TextWrapper = styled.div`
-  margin: 12px 0;
-`;
-
-const ImageWrapper = styled.div`
-  position: relative;
-  padding-bottom: 56%; // 100:56 비율 (높이를 너비의 56%로 설정)
-  width: 100%;
-`;
-
-const Image = styled.img`
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform: translate(50, 50);
-  width: 100%;
-  height: 100%;
-  border-radius: 4px;
-  object-fit: cover;
-`;
-
 const Section = styled.section`
   padding: 0 16px;
-`;
-
-const NewsCard = styled.li`
-  cursor: pointer;
 `;
 
 const MenuBar = styled.div`
@@ -98,6 +75,31 @@ const NewsCardList = styled.ul`
   gap: 12px;
   padding: 16px;
   border-top: 1px solid ${({ theme }) => theme.themeColors.border};
+`;
+
+const NewsCard = styled.li`
+  cursor: pointer;
+`;
+
+const ImageWrapper = styled.div`
+  position: relative;
+  padding-bottom: 56%;
+  width: 100%;
+`;
+
+const Image = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(50, 50);
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  object-fit: cover;
+`;
+
+const TextWrapper = styled.div`
+  margin: 12px 0;
 `;
 
 const Title = styled.h1`

--- a/src/pages/trip/index/components/NewsSection.tsx
+++ b/src/pages/trip/index/components/NewsSection.tsx
@@ -1,107 +1,124 @@
-import { useState } from 'react';
 import styled from 'styled-components';
-import { newsData } from './constants';
+import useNews from '../hooks/useNews';
+import LoadingSpinner from '@/common/components/spinner';
 
-// import useNews from '../hooks/useNews';
-// import LoadingSpinner from '@/common/components/spinner';
+interface NewsSectionProps {
+  calendarId: string;
+}
 
-// interface NewsSectionProps {
-//   calendarId: string;
-// }
+const NewsSection = ({ calendarId }: NewsSectionProps) => {
+  const { data: newsData, isLoading, isError, error } = useNews(calendarId);
 
-const NewsSection = () => {
-  // TODO: API 연동 후 주석 해제
-  // const NewsSection = ({ calendarId }: NewsSectionProps) => {
-  // const { data: newsData, isLoading, isError, error } = useNews(calendarId);
+  const category = ['최신 기사'];
 
-  const [activeTab, setActiveTab] = useState(0);
+  if (isLoading) {
+    // TODO: 추후 로딩 페이지 추가
+    return <LoadingSpinner />;
+  }
 
-  const categoryTabs = newsData.itemList.map((news) => news.category);
-
-  const sortedNews = categoryTabs.map((category: string) =>
-    newsData.itemList.find((news) => news.category === category),
-  );
-
-  // TODO: API 연동 후 주석 해제
-  // if (isLoading) {
-  //   // TODO: 추후 로딩 페이지 추가
-  //   return <LoadingSpinner />;
-  // }
-  // if (isError || !newsData.itemList || newsData.itemList.length === 0) {
-  //   const errorMessage = error?.message || '뉴스 데이터를 가져오는 중 문제가 발생했습니다.';
-  //   return (
-  //     <Section>
-  //       <p>{errorMessage}</p>
-  //     </Section>
-  //   );
-  // }
+  if (isError || !newsData?.itemList || newsData.itemList.length === 0) {
+    const errorMessage = error?.message || '뉴스 데이터를 가져오는 중 문제가 발생했습니다.';
+    return (
+      <Section>
+        <p>{errorMessage}</p>
+      </Section>
+    );
+  }
 
   return (
     <section>
       <MenuBar>
-        {categoryTabs.map((tab: string, index: number) => (
-          <Tab key={index} className={activeTab === index ? 'active' : ''} onClick={() => setActiveTab(index)}>
-            {tab}
-          </Tab>
-        ))}
+        <Tab>{category[0]}</Tab>
       </MenuBar>
-      <TextWrapper>
-        <Title>{sortedNews[activeTab]?.title}</Title>
-        <Description>{sortedNews[activeTab]?.content}</Description>
-        <MoreButton onClick={() => window.open(sortedNews[activeTab]?.url, '_blank')}>자세히 보기</MoreButton>
-      </TextWrapper>
+      <NewsCardList>
+        {newsData?.itemList.map((news, index) => (
+          <NewsCard key={index} onClick={() => window.open(news?.url, '_blank')}>
+            <ImageWrapper>
+              <Image src={news.img} alt="news" />
+            </ImageWrapper>
+            <TextWrapper>
+              <Title>{news?.title}</Title>
+              <Description>{news?.content}</Description>
+            </TextWrapper>
+          </NewsCard>
+        ))}
+      </NewsCardList>
     </section>
   );
 };
 
-// const Section = styled.section`
-//   padding: 0 16px;
-// `;
+const TextWrapper = styled.div`
+  margin: 12px 0;
+`;
 
-const MenuBar = styled.ul`
+const ImageWrapper = styled.div`
+  position: relative;
+  padding-bottom: 56%; // 100:56 비율 (높이를 너비의 56%로 설정)
+  width: 100%;
+`;
+
+const Image = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(50, 50);
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  object-fit: cover;
+`;
+
+const Section = styled.section`
+  padding: 0 16px;
+`;
+
+const NewsCard = styled.li`
+  cursor: pointer;
+`;
+
+const MenuBar = styled.div`
   display: flex;
   margin: 0 16px;
 `;
 
-const Tab = styled.li`
+const Tab = styled.span`
   flex: 1;
-  padding: 16px 0 13px 0;
-  border-bottom: 3px solid ${({ theme }) => theme.colors.gray};
+  max-width: 30%;
+  padding: 16px 0 12px 0;
+  border-bottom: 3px solid ${({ theme }) => theme.themeColors.secondary};
   ${({ theme }) => theme.typography.label.bold};
   text-align: center;
-  color: ${({ theme }) => theme.themeColors.textSecondary};
   cursor: pointer;
-
-  &.active {
-    border-color: ${({ theme }) => theme.themeColors.secondary};
-    color: ${({ theme }) => theme.themeColors.textPrimary};
-  }
+  color: ${({ theme }) => theme.themeColors.textPrimary};
 `;
 
-const TextWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding: 0 16px;
+const NewsCardList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  padding: 16px;
   border-top: 1px solid ${({ theme }) => theme.themeColors.border};
 `;
 
 const Title = styled.h1`
-  padding: 20px 0 12px;
-  ${({ theme }) => theme.typography.title1.bold};
-  text-align: center;
+  ${({ theme }) => theme.typography.body1.medium};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  height: 3em;
 `;
 
 const Description = styled.p`
-  padding: 4px 0 12px;
-`;
-
-const MoreButton = styled.button`
-  margin: 12px 0;
-  padding: 10px 0;
-  background-color: ${({ theme }) => theme.colors.orange200};
-  border-radius: 4px;
-  ${({ theme }) => theme.typography.label.bold};
-  cursor: pointer;
+  ${({ theme }) => theme.typography.body2.regular};
+  color: ${({ theme }) => theme.themeColors.textSecondary};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  height: 4.5em;
 `;
 
 export default NewsSection;

--- a/src/pages/trip/index/components/WeatherSection.tsx
+++ b/src/pages/trip/index/components/WeatherSection.tsx
@@ -6,6 +6,8 @@ interface WeatherSectionProps {
   calendarId: string;
 }
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 const WeatherSection = ({ calendarId }: WeatherSectionProps) => {
   const { data: weatherData, isLoading, isError, error } = useWeather(calendarId);
 
@@ -30,7 +32,7 @@ const WeatherSection = ({ calendarId }: WeatherSectionProps) => {
         <WeatherHeader>오늘의 날씨</WeatherHeader>
         <ContentSubTitle>{weatherData.weather}</ContentSubTitle>
       </ContentWrapper>
-      <WeatherImage src={weatherData.img} alt="weather" />
+      <WeatherImage src={`${BASE_URL}${weatherData.img}`} alt="weather" />
     </Section>
   );
 };

--- a/src/pages/trip/index/components/constants.ts
+++ b/src/pages/trip/index/components/constants.ts
@@ -1,30 +1,30 @@
 const newsData = {
   itemList: [
     {
-      category: '종합',
       title: '아폴로17, 월면 활동 개시',
       content: '아폴로 17호는 1972년 12월 7일 미국 미국항공우주국(NASA)에 의해 발사된 유인 우주선이다.',
       url: 'https://news.example.com/general',
+      img: 'https://images.unsplash.com/photo-1504711331083-9c895941bf81?q=80&w=3570&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     },
     {
-      category: '연예',
       title: '애플 CEO도 트럼프에 15억 기부… 빅테크 줄줄이 뭉칫돈',
       content: '미국 빅테크 업계 거물들이 잇따라 트럼프 취임위원회에 거액을 내놓고 있다.',
       url: 'https://news.example.com/entertainment',
+      img: 'https://images.unsplash.com/photo-1504711331083-9c895941bf81?q=80&w=3570&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     },
     {
-      category: '스포츠',
       title: '맨체스터 시티가 돌아왔다!',
       content:
         '우리가 알던 맨체스터 시티(이하 맨시티)가 돌아왔다. 엘링 홀란의 멀티골과 사비뉴의 2도움 맹활약을 앞세워 웨스트햄 유나이티드를 4-1로 꺾고 2연승을 질주했다.',
       url: 'https://news.example.com/sports',
+      img: 'https://images.unsplash.com/photo-1504711331083-9c895941bf81?q=80&w=3570&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     },
     {
-      category: 'IT',
       title: 'MS “AI 데이터센터 구축에 연간 800억달러 투자할 것',
       content:
         '마이크로소프트(MS)가 인공지능(AI) 기술 구현을 위한 데이터센터에 연간 800억달러(약 117조7천600억원)를 투자한다고 3일(현지시간) 밝혔습니다.',
       url: 'https://news.example.com/tech',
+      img: 'https://images.unsplash.com/photo-1504711331083-9c895941bf81?q=80&w=3570&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     },
   ],
 };

--- a/src/pages/trip/index/index.tsx
+++ b/src/pages/trip/index/index.tsx
@@ -24,9 +24,7 @@ const Trip = () => {
         rightContent={<AppBar.Heart disabled onClick={() => {}} />}
       />
       <Container>
-        <NewsSection
-        // calendarId={calendarId}
-        />
+        <NewsSection calendarId={calendarId} />
         <WeatherSection calendarId={calendarId} />
         <MusicChart calendarId={calendarId} />
         <MovieChart calendarId={calendarId} />


### PR DESCRIPTION
## #18 

📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- [X] 서버 데이터 카테고리 삭제에 따른 탭 ui 삭제
- [X] 이미지 url 추가로 뉴스 카드 ui로 변경
- [X] 배포에 맞게 api 연동 완료

<img width="500" alt="Screenshot 2025-01-16 at 6 25 27 PM" src="https://github.com/user-attachments/assets/0356c1d5-94c7-4a1e-bf8c-d286addaabfd" />
<img width="500" alt="Screenshot 2025-01-16 at 6 24 37 PM" src="https://github.com/user-attachments/assets/ed2a1ccc-c122-4fdd-a4dd-e275045cfeec" />


💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

디코에서 언급드렸던 것처럼, 기존에 사용하려던 빅카인즈(카테고리 기반 뉴스 제공 서비스)에서 뉴스 데이터를 받아 올 수 없게 됐어요. 그래서 카테고리는 없지만 1970년대부터 기사를 제공하는 J신문의 뉴스만 크롤링하기로 했어요. 이거에 맞춰 프론트에서도 카테고리 탭을 없애고 대신 이미지를 받아서 보여주는 방식으로 디자인을 변경했고 ui에 반영해보았습니다.