### PR TITLE
빌드 시 발생한 에러 수정 

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; img-src * data:; style-src 'self' 'unsafe-inline'; connect-src 'self' %VITE_API_BASE_URL%; frame-src *;" />
-
   <title>헤윰 - 디지털 시간여행 플랫폼</title>
-
 </head>
 
 <body>

--- a/src/common/apis/chatting/index.ts
+++ b/src/common/apis/chatting/index.ts
@@ -1,4 +1,4 @@
-import { publicApiInstance } from '../instances';
+import { publicApiInstance, privateApiInstance } from '../instances';
 import { ChatListResponse, ChatMessageResponse } from './types';
 
 export const chatApi = {
@@ -7,7 +7,7 @@ export const chatApi = {
     return response.data;
   },
   getChatMessages: async (roomId: number) => {
-    const response = await publicApiInstance.get<ChatMessageResponse>(`/chat/${roomId}`);
+    const response = await privateApiInstance.get<ChatMessageResponse>(`/chat/${roomId}`);
     return response.data;
   },
 };

--- a/src/pages/trip/index/index.tsx
+++ b/src/pages/trip/index/index.tsx
@@ -28,7 +28,7 @@ const TripPage = () => {
   const { mutate: toggleFavorite } = usePutFavorite();
   const isLogin = useAuthStore.getState().isLogin();
 
-  const isActive = favoriteData.isFavorite;
+  const isActive = favoriteData && favoriteData.isFavorite ? favoriteData.isFavorite : false;
 
   if (!calendarId) {
     // TODO: 추후 에러 컴포넌트 추가

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-  base: process.env.NODE_ENV === 'development' ? '/' : './',
+  base: '/',
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
## #️⃣#87


📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [X] build 경로 문제 수정
- [X] 기능 변경에 따라 `getChatMessages`의 `publicApiInstance`를 `privateApiInstance`로 변경
- [X] 찜조회 `GET`은 회원만 요청 가능하도록 수정


## 문제

배포 후 아래와 같은 에러가 생겼습니다.

<img width="1341" alt="Screenshot 2025-01-30 at 12 49 17 AM" src="https://github.com/user-attachments/assets/369ff51a-78b2-4563-a006-508646903b4f" />

```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/html". Strict MIME type checking is enforced for module scripts per HTML spec.
```

## 원인
처음엔 브라우저 요청이랑 서버 응답이 일치하지 않아, `Content-Type` 문제라고 생각해 서버에서 `Content-Type`을 여러 가지로 변경해 봤지만, 오류가 해결되지 않았습니다.

하지만 해당 페이지가 `https://www.haeyum.kr/oauth/kakao/authorize/`에서 로드되었기 때문에, 브라우저가 js 파일을 잘못된 경로에서 찾은 것이 실제 원인이었습니다.

  - 잘못된 경로 요청
    `https://www.haeyum.kr/oauth/kakao/authorize/assets/js/index-Dfo1O2dR.js`

  - 실제 js 파일 경로
    `https://www.haeyum.kr/assets/js/index-Dfo1O2dR.js`

즉, `index.js`의 경로가 상대 경로로 되어있어, 리다이렉션 과정에 경로가 잘못 설정된 것이 문제였습니다.


## 해결
해결을 위해 `vite.config.js`에서 `base`를 아래와 같이 수정했습니다.

```js
base: '/',
```

이렇게 설정하면, Vite가 빌드할 때 경로를 절대 경로(`/`)로 변환해, 브라우저가 올바른 경로의 파일을 찾을 수 있습니다.

- 기존 코드 (잘못된 경로)
```html
<script type="module" crossorigin src="./assets/js/index-BUchQLje.js"></script>
```

- 수정된 코드 (올바른 경로)
```html
<script type="module" crossorigin src="/assets/js/index-BUchQLje.js"></script>
```
<img width="500" alt="Screenshot 2025-01-30 at 12 08 05 AM" src="https://github.com/user-attachments/assets/9acf122f-eafe-45e9-915f-61748a75ca6f" />

## 추가
현재 이렇게 절대 경로만 적용했지만, 추후 환경 변수에 따라 `base`를 동적으로 설정하려 합니다. (기존의 코드처럼)
